### PR TITLE
Widgets

### DIFF
--- a/composables/use-database.ts
+++ b/composables/use-database.ts
@@ -44,8 +44,7 @@ interface WidgetType {
   title: string
   type: 'number' | 'string'
 }
-
-interface ExistingWidgetType {
+export interface ExistingWidgetType {
   id: string
   title: string
   widgetTypeId: string

--- a/composables/use-database.ts
+++ b/composables/use-database.ts
@@ -1,6 +1,7 @@
 export interface PulseType {
   workspaces: WorkspaceType[]
   users: UserType[]
+  widgets: WidgetsType
 }
 
 export interface UserType {
@@ -27,16 +28,34 @@ export interface ReviewType {
   startDate: string
   slug: string
   schema: SchemaType[]
-  entry: EntryType
 }
 
 interface SchemaType {
-  title: string
-  id: string
+  widgetId: string
 }
 
-interface EntryType {
-  [key: string]: number | string | null
+interface WidgetsType {
+  widgetTypes: WidgetType[]
+  existingWidgets: ExistingWidgetType[]
+}
+
+interface WidgetType {
+  id: string
+  title: string
+  type: 'number' | 'string'
+}
+
+interface ExistingWidgetType {
+  id: string
+  title: string
+  widgetTypeId: string
+  data: WidgetDataType[]
+}
+
+interface WidgetDataType {
+  _date: string
+  _user: number | null
+  value: number
 }
 
 export default () =>
@@ -68,20 +87,12 @@ export default () =>
                 slug: 'weekly-dora-2024-02-12',
                 schema: [
                   {
-                    title: 'MTTR widget',
-                    id: 'mttr-widget',
+                    widgetId: 'mttr-widget-team-1',
                   },
                   {
-                    title: 'Frequency widget',
-                    id: 'frequency-widget',
+                    widgetId: 'frequency-widget-team-1',
                   },
                 ],
-                entry: {
-                  '_date': '2024-02-12',
-                  '_user': 1,
-                  'mttr-widget': 1,
-                  'frequency-widget': 2,
-                },
               },
               {
                 recurrence: 'weekly',
@@ -90,20 +101,12 @@ export default () =>
                 slug: 'weekly-dora-2024-02-05',
                 schema: [
                   {
-                    title: 'MTTR widget',
-                    id: 'mttr-widget',
+                    widgetId: 'mttr-widget-team-1',
                   },
                   {
-                    title: 'Frequency widget',
-                    id: 'frequency-widget',
+                    widgetId: 'frequency-widget-team-1',
                   },
                 ],
-                entry: {
-                  '_date': '2024-02-05',
-                  '_user': 1,
-                  'mttr-widget': 1,
-                  'frequency-widget': 2,
-                },
               },
               {
                 recurrence: 'weekly',
@@ -112,20 +115,12 @@ export default () =>
                 slug: 'weekly-dora-2024-01-15',
                 schema: [
                   {
-                    title: 'MTTR widget',
-                    id: 'mttr-widget',
+                    widgetId: 'mttr-widget-team-1',
                   },
                   {
-                    title: 'Frequency widget',
-                    id: 'frequency-widget',
+                    widgetId: 'frequency-widget-team-1',
                   },
                 ],
-                entry: {
-                  '_date': '2024-01-15',
-                  '_user': 1,
-                  'mttr-widget': 1,
-                  'frequency-widget': 2,
-                },
               },
               {
                 recurrence: 'weekly',
@@ -134,20 +129,12 @@ export default () =>
                 slug: 'weekly-dora-2024-01-22',
                 schema: [
                   {
-                    title: 'MTTR widget',
-                    id: 'mttr-widget',
+                    widgetId: 'mttr-widget-team-1',
                   },
                   {
-                    title: 'Frequency widget',
-                    id: 'frequency-widget',
+                    widgetId: 'frequency-widget-team-1',
                   },
                 ],
-                entry: {
-                  '_date': '2024-01-22',
-                  '_user': 1,
-                  'mttr-widget': 10,
-                  'frequency-widget': 5,
-                },
               },
               {
                 recurrence: 'weekly',
@@ -156,20 +143,12 @@ export default () =>
                 slug: 'weekly-dora-2024-01-29',
                 schema: [
                   {
-                    title: 'MTTR widget',
-                    id: 'mttr-widget',
+                    widgetId: 'mttr-widget-team-1',
                   },
                   {
-                    title: 'Frequency widget',
-                    id: 'frequency-widget',
+                    widgetId: 'frequency-widget-team-1',
                   },
                 ],
-                entry: {
-                  '_date': '2024-01-29',
-                  '_user': 1,
-                  'mttr-widget': 3,
-                  'frequency-widget': 4,
-                },
               },
             ],
           },
@@ -185,19 +164,113 @@ export default () =>
                 slug: 'monthly-devex',
                 schema: [
                   {
-                    title: 'Potato',
-                    id: 'potato',
+                    widgetId: 'potato-widget-1',
                   },
                   {
-                    title: 'Tomato',
-                    id: 'tomato',
+                    widgetId: 'tomato-widget-1',
                   },
                 ],
-                entry: {},
               },
             ],
           },
         ],
       },
     ],
+    widgets: {
+      widgetTypes: [
+        {
+          id: 'mttr',
+          title: 'MTTR',
+          type: 'number',
+        },
+        {
+          id: 'frequency',
+          title: 'Frequency',
+          type: 'number',
+        },
+        {
+          id: 'number',
+          title: 'Number',
+          type: 'number',
+        },
+      ],
+      existingWidgets: [
+        {
+          id: 'mttr-widget-team-1',
+          title: 'MTTR for team 1',
+          widgetTypeId: 'mttr',
+          data: [
+            {
+              _date: '2024-01-15',
+              _user: 1,
+              value: 3,
+            },
+            {
+              _date: '2024-01-22',
+              _user: 1,
+              value: 2,
+            },
+            {
+              _date: '2024-01-29',
+              _user: 1,
+              value: 1,
+            },
+            {
+              _date: '2024-02-05',
+              _user: 1,
+              value: 3,
+            },
+            {
+              _date: '2024-02-12',
+              _user: 1,
+              value: 5,
+            },
+          ],
+        },
+        {
+          id: 'frequency-widget-team-1',
+          title: 'Frequency for team 1',
+          widgetTypeId: 'frequency',
+          data: [
+            {
+              _date: '2024-01-15',
+              _user: 1,
+              value: 2,
+            },
+            {
+              _date: '2024-01-22',
+              _user: 1,
+              value: 4,
+            },
+            {
+              _date: '2024-01-29',
+              _user: 1,
+              value: 5,
+            },
+            {
+              _date: '2024-02-05',
+              _user: 1,
+              value: 2,
+            },
+            {
+              _date: '2024-02-12',
+              _user: 1,
+              value: 7,
+            },
+          ],
+        },
+        {
+          id: 'potato-widget-1',
+          title: 'Potato',
+          widgetTypeId: 'number',
+          data: [],
+        },
+        {
+          id: 'tomato-widget-1',
+          title: 'Tomato',
+          widgetTypeId: 'number',
+          data: [],
+        },
+      ],
+    },
   }))

--- a/composables/use-database.ts
+++ b/composables/use-database.ts
@@ -52,9 +52,9 @@ export interface ExistingWidgetType {
 }
 
 interface WidgetDataType {
-  _date: string
-  _user: number | null
-  value: number
+  _date: string;
+  _user: number | null;
+  value: number | string | null;
 }
 
 export default () =>

--- a/pages/[workspaceSlug]/[folderSlug]/index.vue
+++ b/pages/[workspaceSlug]/[folderSlug]/index.vue
@@ -44,8 +44,7 @@ const inProgressReviews = computed(() =>
 function createDraftFrom(review: ReviewType) {
   folder.value.reviews.unshift({
     ...review,
-    status: 'draft',
-    entry: {},
+    status: "draft",
     slug: (Math.random() + 1).toString(36).substring(7),
     startDate: getStartDate(folder.value),
   })


### PR DESCRIPTION
Opening a PR so we can discuss it here.

I changed the schema so that the widgets are separate. We have `widgetTypes` which are kinda like a template for a widget. And `existingWidgets` are the database of created widgets, which are now storing data.

Next thing to do:
- add a selector when adding a new widget on a review - choose from an empty template or add an existing one
- add a view for widget historical data
- (?) add a fake config - not sure if we have open questions about this. The only one that came to mind was - can I have the same widget in different reviews, but with different titles and assignees